### PR TITLE
avoid name collision

### DIFF
--- a/contracts/endpoint/endpoint.go
+++ b/contracts/endpoint/endpoint.go
@@ -7,7 +7,7 @@ import (
 
 type (
 	IEndpointRegistration interface {
-		Register(s *grpc.Server)
-		RegisterHandler(gwmux *grpc_gateway_runtime.ServeMux, conn *grpc.ClientConn)
+		RegisterFluffyCoreGRPCService(s *grpc.Server)
+		RegisterFluffyCoreHandler(gwmux *grpc_gateway_runtime.ServeMux, conn *grpc.ClientConn)
 	}
 )

--- a/proto/helloworld/helloworld_fluffycore_di.pb.go
+++ b/proto/helloworld/helloworld_fluffycore_di.pb.go
@@ -20,7 +20,7 @@ type IFluffyCoreGreeterServer interface {
 type UnimplementedFluffyCoreGreeterServerEndpointRegistration struct {
 }
 
-func (UnimplementedFluffyCoreGreeterServerEndpointRegistration) RegisterHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
+func (UnimplementedFluffyCoreGreeterServerEndpointRegistration) RegisterFluffyCoreHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
 }
 
 // GreeterFluffyCoreServer defines the grpc server truct
@@ -29,8 +29,8 @@ type GreeterFluffyCoreServer struct {
 	UnimplementedFluffyCoreGreeterServerEndpointRegistration
 }
 
-// Register the server with grpc
-func (srv *GreeterFluffyCoreServer) Register(s *grpc.Server) {
+// RegisterFluffyCoreGRPCService the server with grpc
+func (srv *GreeterFluffyCoreServer) RegisterFluffyCoreGRPCService(s *grpc.Server) {
 	RegisterGreeterServer(s, srv)
 }
 
@@ -62,7 +62,7 @@ type IFluffyCoreGreeter2Server interface {
 type UnimplementedFluffyCoreGreeter2ServerEndpointRegistration struct {
 }
 
-func (UnimplementedFluffyCoreGreeter2ServerEndpointRegistration) RegisterHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
+func (UnimplementedFluffyCoreGreeter2ServerEndpointRegistration) RegisterFluffyCoreHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
 }
 
 // Greeter2FluffyCoreServer defines the grpc server truct
@@ -71,8 +71,8 @@ type Greeter2FluffyCoreServer struct {
 	UnimplementedFluffyCoreGreeter2ServerEndpointRegistration
 }
 
-// Register the server with grpc
-func (srv *Greeter2FluffyCoreServer) Register(s *grpc.Server) {
+// RegisterFluffyCoreGRPCService the server with grpc
+func (srv *Greeter2FluffyCoreServer) RegisterFluffyCoreGRPCService(s *grpc.Server) {
 	RegisterGreeter2Server(s, srv)
 }
 
@@ -104,7 +104,7 @@ type IFluffyCoreMyStreamServiceServer interface {
 type UnimplementedFluffyCoreMyStreamServiceServerEndpointRegistration struct {
 }
 
-func (UnimplementedFluffyCoreMyStreamServiceServerEndpointRegistration) RegisterHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
+func (UnimplementedFluffyCoreMyStreamServiceServerEndpointRegistration) RegisterFluffyCoreHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
 }
 
 // MyStreamServiceFluffyCoreServer defines the grpc server truct
@@ -113,8 +113,8 @@ type MyStreamServiceFluffyCoreServer struct {
 	UnimplementedFluffyCoreMyStreamServiceServerEndpointRegistration
 }
 
-// Register the server with grpc
-func (srv *MyStreamServiceFluffyCoreServer) Register(s *grpc.Server) {
+// RegisterFluffyCoreGRPCService the server with grpc
+func (srv *MyStreamServiceFluffyCoreServer) RegisterFluffyCoreGRPCService(s *grpc.Server) {
 	RegisterMyStreamServiceServer(s, srv)
 }
 

--- a/proto/someservice/someservice_fluffycore_di.pb.go
+++ b/proto/someservice/someservice_fluffycore_di.pb.go
@@ -20,7 +20,7 @@ type IFluffyCoreSomeServiceServer interface {
 type UnimplementedFluffyCoreSomeServiceServerEndpointRegistration struct {
 }
 
-func (UnimplementedFluffyCoreSomeServiceServerEndpointRegistration) RegisterHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
+func (UnimplementedFluffyCoreSomeServiceServerEndpointRegistration) RegisterFluffyCoreHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
 }
 
 // SomeServiceFluffyCoreServer defines the grpc server truct
@@ -29,8 +29,8 @@ type SomeServiceFluffyCoreServer struct {
 	UnimplementedFluffyCoreSomeServiceServerEndpointRegistration
 }
 
-// Register the server with grpc
-func (srv *SomeServiceFluffyCoreServer) Register(s *grpc.Server) {
+// RegisterFluffyCoreGRPCService the server with grpc
+func (srv *SomeServiceFluffyCoreServer) RegisterFluffyCoreGRPCService(s *grpc.Server) {
 	RegisterSomeServiceServer(s, srv)
 }
 
@@ -62,7 +62,7 @@ type IFluffyCoreSomeService2Server interface {
 type UnimplementedFluffyCoreSomeService2ServerEndpointRegistration struct {
 }
 
-func (UnimplementedFluffyCoreSomeService2ServerEndpointRegistration) RegisterHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
+func (UnimplementedFluffyCoreSomeService2ServerEndpointRegistration) RegisterFluffyCoreHandler(gwmux *runtime.ServeMux, conn *grpc.ClientConn) {
 }
 
 // SomeService2FluffyCoreServer defines the grpc server truct
@@ -71,8 +71,8 @@ type SomeService2FluffyCoreServer struct {
 	UnimplementedFluffyCoreSomeService2ServerEndpointRegistration
 }
 
-// Register the server with grpc
-func (srv *SomeService2FluffyCoreServer) Register(s *grpc.Server) {
+// RegisterFluffyCoreGRPCService the server with grpc
+func (srv *SomeService2FluffyCoreServer) RegisterFluffyCoreGRPCService(s *grpc.Server) {
 	RegisterSomeService2Server(s, srv)
 }
 

--- a/protoc-gen-go-fluffycore-di/cmd/protoc-gen-go-fluffycore-di/di.go
+++ b/protoc-gen-go-fluffycore-di/cmd/protoc-gen-go-fluffycore-di/di.go
@@ -168,7 +168,7 @@ func (s *serviceGenContext) genService() {
 	g.P("}")
 	g.P()
 
-	g.P("func (UnimplementedFluffyCore", service.GoName, "ServerEndpointRegistration) RegisterHandler(gwmux *", grpcGatewayRuntimePackage.Ident("ServeMux"),
+	g.P("func (UnimplementedFluffyCore", service.GoName, "ServerEndpointRegistration) RegisterFluffyCoreHandler(gwmux *", grpcGatewayRuntimePackage.Ident("ServeMux"),
 		",conn *", grpcPackage.Ident("ClientConn"), ") {")
 	g.P("}")
 	g.P()
@@ -182,8 +182,8 @@ func (s *serviceGenContext) genService() {
 	g.P("}")
 	g.P()
 
-	g.P("// Register the server with grpc")
-	g.P("func (srv *", internalServerName, ") Register(s *", grpcPackage.Ident("Server"), ") {")
+	g.P("// RegisterFluffyCoreGRPCService the server with grpc")
+	g.P("func (srv *", internalServerName, ") RegisterFluffyCoreGRPCService(s *", grpcPackage.Ident("Server"), ") {")
 	g.P("   ", "Register", interfaceGRPCServerName, "(s,srv)")
 	g.P("}")
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -240,7 +240,7 @@ func (s *Runtime) StartWithListenter(lis net.Listener, startup fluffycore_contra
 	}
 	endpoints := di.Get[[]fluffycore_contract_endpoint.IEndpointRegistration](si.RootContainer)
 	for _, endpoint := range endpoints {
-		endpoint.Register(grpcServer)
+		endpoint.RegisterFluffyCoreGRPCService(grpcServer)
 	}
 
 	healthServer := di.Get[fluffycore_contracts_health.IHealthServer](si.RootContainer)
@@ -313,7 +313,7 @@ func (s *Runtime) StartWithListenter(lis net.Listener, startup fluffycore_contra
 			serveMuxOptions...,
 		)
 		for _, endpoint := range endpoints {
-			endpoint.RegisterHandler(gwmux, conn)
+			endpoint.RegisterFluffyCoreHandler(gwmux, conn)
 		}
 
 		gwServer := &http.Server{


### PR DESCRIPTION
	IEndpointRegistration interface {
		RegisterFluffyCoreGRPCService(s *grpc.Server)
		RegisterFluffyCoreHandler(gwmux *grpc_gateway_runtime.ServeMux, conn *grpc.ClientConn)
	}